### PR TITLE
Await session closing

### DIFF
--- a/pytest_sanic/utils.py
+++ b/pytest_sanic/utils.py
@@ -224,7 +224,7 @@ class TestClient:
                 resp.close()
             for ws in self._websockets:
                 await ws.close()
-            self._session.close()
+            await self._session.close()
             await self._server.close()
             self._closed = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README_PATH = os.path.join(base, "README.rst")
 install_requires = [
     'pytest',
     'sanic',
-    'aiohttp',
+    'aiohttp>=3',
 ]
 
 tests_require = []


### PR DESCRIPTION
In order to comply with aiohttp >= 3.0 warning `pytest_sanic/utils.py:227: RuntimeWarning: coroutine 'ClientSession.close' was never awaited`

I checked this patch for aiohttp >= 3.0 and 2.0 <= aiohttp < 3.0