### PR TITLE
Do not force people tu upgrade aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README_PATH = os.path.join(base, "README.rst")
 install_requires = [
     'pytest',
     'sanic',
-    'aiohttp>=3.0',
+    'aiohttp',
 ]
 
 tests_require = []


### PR DESCRIPTION
Hi again,

aiobotocore, and probably other packages enforce aiohttp < 3. So it is impossible to upgrade to 1.6.7 because of the 'aiohttp>=3.0'.

Since my fix works also with aiohttp >= 2.0, can you leave aiohttp version choice to the end user ?