### PR TITLE
Following changes in aiohttp, the event loop arg needs to be removed

### DIFF
--- a/pytest_sanic/utils.py
+++ b/pytest_sanic/utils.py
@@ -179,9 +179,8 @@ class TestClient:
                     self._app, loop=self._loop,
                     protocol=self._protocol, ssl=self._ssl,
                     scheme=self._scheme)
-        cookie_jar = CookieJar(unsafe=True, loop=loop)
-        self._session = ClientSession(loop=loop,
-                                      cookie_jar=cookie_jar,
+        cookie_jar = CookieJar(unsafe=True)
+        self._session = ClientSession(cookie_jar=cookie_jar,
                                       **kwargs)
         # Let's collect responses objects and websocket objects,
         # and clean up when test is done.


### PR DESCRIPTION
Following changes here: https://github.com/aio-libs/aiohttp/pull/3580/files

ClientSession and CookieJar no longer accept the event loop as an argument. The following is raised:

```

testing_database_url = 'sqlite:////tmp/tmpnqgsxtib/opentsr.db'
loop = <uvloop.Loop running=False closed=False debug=False>
sanic_client = <function sanic_client.<locals>.create_client at 0x7f828a88d400>

    @pytest.fixture()
    def api(testing_database_url, loop, sanic_client):
        app = create_app(config={"DATABASE_URL": testing_database_url})
>       return loop.run_until_complete(sanic_client(app))

tests/conftest.py:78: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
uvloop/loop.pyx:1417: in uvloop.loop.Loop.run_until_complete
    ???
../.venv/lib/python3.6/site-packages/pytest_sanic/plugin.py:202: in create_client
    client = TestClient(app, loop=loop, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pytest_sanic.utils.TestClient object at 0x7f828aada0f0>
app = <sanic.app.Sanic object at 0x7f829004fe80>
loop = <uvloop.Loop running=False closed=False debug=False>, host = '127.0.0.1'
protocol = None, ssl = None, scheme = None, kwargs = {}

    def __init__(self, app, loop=None,
                 host='127.0.0.1',
                 protocol=None,
                 ssl=None,
                 scheme=None,
                 **kwargs):
        if not isinstance(app, Sanic):
            raise TypeError("app should be a Sanic application.")
        self._app = app
        self._loop = loop
        # we should use '127.0.0.1' in most cases.
        self._host = host
        self._ssl = ssl
        self._scheme = scheme
        self._protocol = HttpProtocol if protocol is None else protocol
        self._closed = False
        self._server = TestServer(
                    self._app, loop=self._loop,
                    protocol=self._protocol, ssl=self._ssl,
                    scheme=self._scheme)
>       cookie_jar = CookieJar(unsafe=True, loop=loop)
E       TypeError: __init__() got an unexpected keyword argument 'loop'

../.venv/lib/python3.6/site-packages/pytest_sanic/utils.py:182: TypeError
```