### PR TITLE
Fix 'DeprecationWarning: passing through `loop` is deprecated'

### DIFF
--- a/pytest_sanic/utils.py
+++ b/pytest_sanic/utils.py
@@ -177,7 +177,6 @@ class TestClient:
                           DeprecationWarning,
                           stacklevel=2)
         self._app = app
-        self._loop = loop or asyncio.get_event_loop()
         # we should use '127.0.0.1' in most cases.
         self._host = host
         self._ssl = ssl
@@ -185,7 +184,7 @@ class TestClient:
         self._protocol = HttpProtocol if protocol is None else protocol
         self._closed = False
         self._server = TestServer(
-                    self._app, loop=self._loop,
+                    self._app, loop=loop,
                     protocol=self._protocol, ssl=self._ssl,
                     scheme=self._scheme)
         cookie_jar = CookieJar(unsafe=True)


### PR DESCRIPTION
Fix for issue #40.

### Background
Running `pytest-sanic` using `sanic_client` in tests has been producing the following warning:

```
  /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pytest_sanic/utils.py:190: DeprecationWarning: passing through `loop` is deprecated.
    scheme=self._scheme)
```

This is produced by runnin the following test:

```python
import pytest
from sanic import Sanic

@pytest.yield_fixture
def app():
    app = Sanic("test_app")
    yield app

@pytest.fixture
def client(loop, app, sanic_client):
    return loop.run_until_complete(sanic_client(app))

async def test_get(client):
    response = await client.get("/")
    assert True
```

The issue appears to arise in the `TestClient` constructor, where `_server` is initialized. Starting with PR #37, both `TestClient` and `TestServer` emit a warning when constructed if passed a non-`None` `loop` parameter.

If `loop` is `None`, the warning shouldn't be emitted. However, `TestClient`, as well as `TestServer`, sets its `self._loop` to `loop` or `asyncio.get_event_loop()` if `loop` isn't initialized, and then passes the initialized `self._loop` into the `TestServer` constructor. This causes `TestServer` to emit a `passing through 'loop' is deprecated` warning.

### What's Been Done
The only place `TestClient`'s `self._loop` property appeared to be used was in providing a `loop` parameter to `TestServer`. Since `TestServer` will perform the same initialization when `loop` arrives in its constructor, it shouldn't need to happen in `TestClient`.

`TestClient::_loop` is removed, and `loop` is just passed directly to `TestServer`.

### Testing
- `poetry run pytest ./tests --cov pytest_sanic` tests passed
- `pytest` tests run against the test above no longer produced the warning:

  `PYTHONPATH=/path/to/local/pytest-sanic/repo python3 -m pytest`