### PR TITLE
Improve Quick Start Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,21 @@ Install
 Quick Start
 -----------
 
-You don't have to load ``pytest-sanic`` explicitly. ``pytest`` will do it for you. Just write tests like,
+You don't have to load ``pytest-sanic`` explicitly. ``pytest`` will do it for you.
+
+You can set up a fixture for your ``app`` like this:
+
+.. code-block:: python
+
+    import pytest
+    from .app import create_app
+
+    @pytest.yield_fixture
+    def app():
+        app = create_app(test_config, **params)
+        yield app
+
+This ``app`` fixture can then be used from tests:
 
 .. code-block:: python
 
@@ -85,21 +99,17 @@ You don't have to load ``pytest-sanic`` explicitly. ``pytest`` will do it for yo
         assert doc.name == "Kobe Bryant"
         assert doc.team == "Lakers"
 
-
-Here's much more realistic & useful example,
+To send requests to your ``app``, you set up a client fixture using the loop_ and sanic_client_ fixtures:
 
 .. code-block:: python
-
-    from .app import create_app
-
-    @pytest.yield_fixture
-    def app():
-        app = create_app(test_config, **params)
-        yield app
 
     @pytest.fixture
     def test_cli(loop, app, sanic_client):
         return loop.run_until_complete(sanic_client(app))
+
+This ``test_cli`` fixture can then be used to send requests to your ``app``:
+
+.. code-block:: python
 
     async def test_index(test_cli):
         resp = await test_cli.get('/')
@@ -108,7 +118,6 @@ Here's much more realistic & useful example,
     async def test_player(test_cli):
         resp = await test_cli.get('/player')
         assert resp.status == 200
-
 
 --------------------
 asynchronous fixture


### PR DESCRIPTION
I found the `Quick Start` section of the `README` a bit confusing when I went through it the first time. This PR reorganises the steps a bit to make it clearer what needs to be done.